### PR TITLE
SAC

### DIFF
--- a/_about-regent/School Advisory Committee.md
+++ b/_about-regent/School Advisory Committee.md
@@ -39,14 +39,6 @@ variant: tiptap
 <p>Member</p>
 </td>
 <td rowspan="1" colspan="1">
-<p>Dr Poon Joe Fai</p>
-</td>
-</tr>
-<tr>
-<td rowspan="1" colspan="1">
-<p>Member</p>
-</td>
-<td rowspan="1" colspan="1">
 <p>Mr Low Chin Kok, PBM</p>
 </td>
 </tr>


### PR DESCRIPTION
Remove Dr Poon’s name from SAC in school website in last week of June 2026 when back in school.
Dr Poon’s term ends on 15 June 2026.
Also Change to:  (from June 2024  2026).
Thanks.
